### PR TITLE
fix: $correlationId not found

### DIFF
--- a/src/Client/SwooleClient.php
+++ b/src/Client/SwooleClient.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace longlang\phpkafka\Client;
 
-use Exception;
 use InvalidArgumentException;
 use longlang\phpkafka\Config\CommonConfig;
+use longlang\phpkafka\Exception\SocketException;
 use longlang\phpkafka\Protocol\AbstractRequest;
 use longlang\phpkafka\Protocol\AbstractResponse;
 use longlang\phpkafka\Protocol\ApiKeys;
@@ -141,9 +141,9 @@ class SwooleClient extends SyncClient
                         continue;
                     }
                     $this->recvChannels[$correlationId]->push($data);
-                } catch (Exception $e) {
-                    foreach ($this->recvChannels as $ch) {
-                        $ch->push($e);
+                } catch (SocketException $e) {
+                    foreach ($this->recvChannels as $channel) {
+                        $channel->push($e);
                     }
                     break;
                 }

--- a/src/Client/SwooleClient.php
+++ b/src/Client/SwooleClient.php
@@ -140,10 +140,13 @@ class SwooleClient extends SyncClient
                     if (!isset($this->recvChannels[$correlationId])) {
                         continue;
                     }
+                    $this->recvChannels[$correlationId]->push($data);
                 } catch (Exception $e) {
-                    $data = $e;
+                    foreach ($this->recvChannels as $ch) {
+                        $ch->push($e);
+                    }
+                    break;
                 }
-                $this->recvChannels[$correlationId]->push($data);
             }
         });
     }


### PR DESCRIPTION
$correlationId will not be available if an exception is thrown. Instead, break out of the recv loop, and notify all channels in recvChannels of the exception.