### PR TITLE
fix: dead loop

### DIFF
--- a/src/Socket/SwooleSocket.php
+++ b/src/Socket/SwooleSocket.php
@@ -128,7 +128,7 @@ class SwooleSocket implements SocketInterface
         $leftTime = $timeout;
         while ($this->socket && !isset($this->receivedBuffer[$length - 1]) && (-1 == $timeout || $leftTime > 0)) {
             $buffer = $this->socket->recv($timeout);
-            if (false === $buffer) {
+            if (empty($buffer)) {
                 throw new SocketException(sprintf('Could not recv data from stream, %s [%d]', $this->socket->errMsg, $this->socket->errCode));
             }
             $this->receivedBuffer .= $buffer;

--- a/src/Socket/SwooleSocket.php
+++ b/src/Socket/SwooleSocket.php
@@ -128,7 +128,7 @@ class SwooleSocket implements SocketInterface
         $leftTime = $timeout;
         while ($this->socket && !isset($this->receivedBuffer[$length - 1]) && (-1 == $timeout || $leftTime > 0)) {
             $buffer = $this->socket->recv($timeout);
-            if (empty($buffer)) {
+            if ($buffer === '' || $buffer === false) {
                 throw new SocketException(sprintf('Could not recv data from stream, %s [%d]', $this->socket->errMsg, $this->socket->errCode));
             }
             $this->receivedBuffer .= $buffer;


### PR DESCRIPTION
According to the document on wiki.swoole.com, the correct way to check disconnection is emtpy($buffer), instead of $buffer===false. 

In our production environment, we periodically encounter infinite recv loops caused by the empty buffer. After the proposed change was made, the occasional dead loop went away.